### PR TITLE
Upgrade to CVXPY >= 1.1.13.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# JetBrains
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ target/
 
 # JetBrains
 .idea/
+

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Example
 -------
 The following code uses NC-ADMM heuristic to approximately solve a least-squares problem where the variable has only ``k`` nonzero components, and all components are between -1 and 1.
 ```
-from cvxpy import sum_squares, sum, Problem, Minimize
-
+import cvxpy as cp
+import ncvx as nc
 
 # Problem data
 m = 30; n = 20; k = 6
@@ -27,29 +27,29 @@ A = numpy.random.randn(m, n)
 b = numpy.random.randn(m)
 
 # NC-ADMM heuristic.
-x = Card(n, k, 1)
-objective = sum_squares(A @ x - b)
-prob = Problem(Minimize(objective), [])
+x = nc.Card(n, k, 1)
+objective = cp.sum_squares(A @ x - b)
+prob = cp.Problem(cp.Minimize(objective), [])
 prob.solve(method="NC-ADMM")
-print objective.value
-print x.value
+print(f"Objective = {objective.value}")
+print(f"x = \n{x.value}")
 ```
 Other solve methods can be used by simply changing the solve method, for example ``prob.solve(method="relax-round-polish")`` uses relax-round-polish to approximately solve the problem. Constraints can be added to the problem similar to CVXPY. For example, the following code approximately solves the above problem, with the additional constraint that the components of ``x`` must add up to zero.
 ```
-x = Card(n, k, M)
-objective = sum_squares(A @ x - b)
-constraints = [sum(x) == 0]
-prob = Problem(Minimize(objective), constraints)
+x = nc.Card(n, k, M)
+objective = cp.sum_squares(A @ x - b)
+constraints = [cp.sum(x) == 0]
+prob = cp.Problem(cp.Minimize(objective), constraints)
 prob.solve(method="NC-ADMM")
-print objective.value
-print x.value
+print(f"Objective = {objective.value}")
+print(f"x = \n{x.value}")
 ```
 
 Variable constructors
 ---------------------
 The following sets are supported by NCVX at the moment:
 * ``Boolean(n)`` creates a variable with ``n`` Boolean components.
-* ``integer(n, M)`` creates a variable with ``n`` integer components between ``-M`` and ``M``.
+* ``Integer(n, M)`` creates a variable with ``n`` integer components between ``-M`` and ``M``.
 * ``Card(n, k, M)`` creates a variable with ``n`` components, with the implicit constraint that at most ``k`` entries are nonzero and all entries are between ``-M`` and ``M``.
 * ``Choose(n, k)`` creates a variable with ``n`` Boolean components, with the implicit constraint that it has exactly ``k`` nonozero entries.
 * ``Annulus(n, r, R)`` creates a variable with ``n`` components with the implicit constraint that its Euclidean norm is between ``r`` and ``R``.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 ------------
 You should first install CVXPY version 0.4. CVXPY install guide can be found [here](http://www.cvxpy.org/). We are working on upgrading NCVX to work with CVXPY 1.0. 
 
-Then install ``scsprox`` from source [here](https://github.com/SteveDiamond/scsprox).
+Then install ``scsprox`` from source [here](https://github.com/bettbra/scsprox).
 
 The easiest way to install the package is to run ``pip install ncvx``. To install the package from source, run ``python setup.py install`` in the main folder. The package has CVXPY and lap as dependencies.
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,28 @@ NCVX is built on top of [CVXPY](http://www.cvxpy.org/), a domain-specific langua
 
 Installation
 ------------
-You should first install CVXPY version 0.4. CVXPY install guide can be found [here](http://www.cvxpy.org/). We are working on upgrading NCVX to work with CVXPY 1.0. 
+You should first install CVXPY version >= 1.1.13. The CVXPY install guide can be found [here](http://www.cvxpy.org/).
 
 Then install ``scsprox`` from source [here](https://github.com/bettbra/scsprox).
 
-The easiest way to install the package is to run ``pip install ncvx``. To install the package from source, run ``python setup.py install`` in the main folder. The package has CVXPY and lap as dependencies.
+The easiest way to install the package is to run ``pip install ncvx``. To install the package from source, run ``python setup.py install`` in the main folder.
 
 Example
 -------
 The following code uses NC-ADMM heuristic to approximately solve a least-squares problem where the variable has only ``k`` nonzero components, and all components are between -1 and 1.
 ```
+from cvxpy import sum_squares, sum, Problem, Minimize
+
+
 # Problem data
 m = 30; n = 20; k = 6
 numpy.random.seed(1)
 A = numpy.random.randn(m, n)
 b = numpy.random.randn(m)
 
-#NC-ADMM heuristic.
+# NC-ADMM heuristic.
 x = Card(n, k, 1)
-objective = sum_squares(A*x - b)
+objective = sum_squares(A @ x - b)
 prob = Problem(Minimize(objective), [])
 prob.solve(method="NC-ADMM")
 print objective.value
@@ -34,7 +37,7 @@ print x.value
 Other solve methods can be used by simply changing the solve method, for example ``prob.solve(method="relax-round-polish")`` uses relax-round-polish to approximately solve the problem. Constraints can be added to the problem similar to CVXPY. For example, the following code approximately solves the above problem, with the additional constraint that the components of ``x`` must add up to zero.
 ```
 x = Card(n, k, M)
-objective = sum_squares(A*x - b)
+objective = sum_squares(A @ x - b)
 constraints = [sum(x) == 0]
 prob = Problem(Minimize(objective), constraints)
 prob.solve(method="NC-ADMM")
@@ -51,8 +54,8 @@ The following sets are supported by NCVX at the moment:
 * ``Choose(n, k)`` creates a variable with ``n`` Boolean components, with the implicit constraint that it has exactly ``k`` nonozero entries.
 * ``Annulus(n, r, R)`` creates a variable with ``n`` components with the implicit constraint that its Euclidean norm is between ``r`` and ``R``.
 * ``Sphere(n, r)`` creates a variable with ``n`` components with the implicit constraint that its Euclidean norm is equal to ``r``.
-* ``Rank(m, n, k, M)`` creates a ``m x n`` matrix variable with the implicit constraints that its rank is at most ``k`` and its Euclidean norm is at most ``M``.
-* ``Assign(m, n) `` creates a ``m x n`` matrix variable with the implicit constraint that it is an assignment matrix.
+* ``Rank((m, n), k, M)`` creates a ``m x n`` matrix variable with the implicit constraints that its rank is at most ``k`` and its Euclidean norm is at most ``M``.
+* ``Assign((m, n)) `` creates a ``m x n`` matrix variable with the implicit constraint that it is an assignment matrix.
 * ``Permute(n)`` creates a ``n x n`` matrix variable with the implicit constraint that it is a permutation matrix.
 * ``Cycle(n)`` creates a ``n x n`` matrix variable with the implicit constraint that it is the adjacency matrix of a Hamiltonian cycle.
 

--- a/examples/circle_packing.py
+++ b/examples/circle_packing.py
@@ -1,12 +1,14 @@
 import cvxpy as cp
 import numpy as np
 import matplotlib.pyplot as plt
-import ncvx
+import ncvx as nc
 
-np.random.seed(1)
+# This example is described in Section 6.3 of the NCVX paper.
 
-N = 41                             # number of circles
-r = 0.4 + 0.6 * np.random.rand(N)  # radii
+rng = np.random.default_rng(seed=123)
+
+N = 41                         # number of circles
+r = 0.2 + 0.3 * rng.random(N)  # radii
 
 # Define variables.
 x_vals = [cp.Variable() for i in range(N)]
@@ -15,13 +17,13 @@ y_vals = [cp.Variable() for i in range(N)]
 objective = cp.Minimize(cp.maximum(*(x_vals + y_vals)) + 0.5)
 constraints = []
 for i in range(N):
-    constraints += [0.5 * r[i] <= x_vals[i],
-                    0.5 * r[i] <= y_vals[i]]
+    constraints += [r[i] <= x_vals[i],
+                    r[i] <= y_vals[i]]
 diff_vars = []
-for i in range(N-1):
-    for j in range(i+1, N):
+for i in range(N - 1):
+    for j in range(i + 1, N):
         t = cp.Variable()
-        diff_vars.append(ncvx.Annulus(2, 0.5 * (r[i] + r[j]), N))
+        diff_vars.append(nc.Annulus(2, r[i] + r[j], N))
         constraints += [
              cp.vstack((x_vals[i] - x_vals[j], y_vals[i] - y_vals[j])) == diff_vars[-1]]
 
@@ -31,7 +33,7 @@ result = prob.solve(method="relax-round-polish", polish_depth=100)
 # Plot the circles.
 circ = np.linspace(0, 2 * np.pi)
 for i in range(N):
-    plt.plot(x_vals[i].value + 0.5 * r[i] * np.cos(circ), y_vals[i].value + 0.5 * r[i] * np.sin(circ), 'b')
+    plt.plot(x_vals[i].value + r[i] * np.cos(circ), y_vals[i].value + r[i] * np.sin(circ), 'b')
 plt.xlim([0, objective.value])
 plt.ylim([0, objective.value])
 plt.axes().set_aspect('equal')

--- a/examples/circle_packing.py
+++ b/examples/circle_packing.py
@@ -1,36 +1,38 @@
-import cvxpy as cp, numpy as np, cvxopt, matplotlib.pyplot as plt
+import cvxpy as cp
+import numpy as np
+import matplotlib.pyplot as plt
 import ncvx
 
 np.random.seed(1)
 
-N = 41 # number of circles
-r = 0.4 + 0.6 * np.random.rand(N) # radii
+N = 41                             # number of circles
+r = 0.4 + 0.6 * np.random.rand(N)  # radii
 
-#define variables.
+# Define variables.
 x_vals = [cp.Variable() for i in range(N)]
 y_vals = [cp.Variable() for i in range(N)]
 
-objective = cp.Minimize(cp.maximum( *(x_vals + y_vals) ) + 0.5)
+objective = cp.Minimize(cp.maximum(*(x_vals + y_vals)) + 0.5)
 constraints = []
 for i in range(N):
-    constraints  += [0.5*r[i] <= x_vals[i],
-                     0.5*r[i] <= y_vals[i]]
+    constraints += [0.5 * r[i] <= x_vals[i],
+                    0.5 * r[i] <= y_vals[i]]
 diff_vars = []
 for i in range(N-1):
-    for j in range(i+1,N):
+    for j in range(i+1, N):
         t = cp.Variable()
-        diff_vars.append(ncvx.Annulus(2, 0.5 * (r[i]+r[j]), N))
+        diff_vars.append(ncvx.Annulus(2, 0.5 * (r[i] + r[j]), N))
         constraints += [
-            cp.vstack((x_vals[i] - x_vals[j], y_vals[i] - y_vals[j])) == diff_vars[-1]]
+             cp.vstack((x_vals[i] - x_vals[j], y_vals[i] - y_vals[j])) == diff_vars[-1]]
 
 prob = cp.Problem(objective, constraints)
 result = prob.solve(method="relax-round-polish", polish_depth=100)
 
-#plot the circles
-circ = np.linspace(0,2 * np.pi)
+# Plot the circles.
+circ = np.linspace(0, 2 * np.pi)
 for i in range(N):
-    plt.plot(x_vals[i].value+0.5*r[i]*np.cos(circ),y_vals[i].value+0.5*r[i]*np.sin(circ),'b')
-plt.xlim([0,objective.value])
-plt.ylim([0,objective.value])
+    plt.plot(x_vals[i].value + 0.5 * r[i] * np.cos(circ), y_vals[i].value + 0.5 * r[i] * np.sin(circ), 'b')
+plt.xlim([0, objective.value])
+plt.ylim([0, objective.value])
 plt.axes().set_aspect('equal')
 plt.show()

--- a/examples/factor_model.py
+++ b/examples/factor_model.py
@@ -8,32 +8,34 @@ random.seed(1)
 
 
 # Generating problem data
-n = 12; k = n//2
+n = 12
+k = n // 2
 print("n =", n, ", k =", k)
 SNR = 20
 F = np.random.randn(n, k)
 D_true = np.random.exponential(1, size=(n, 1))
 Sigma_true = F.dot(F.T) + np.diag(D_true)
-variance = norm(Sigma_true, 'fro').value/(np.sqrt(n*n)*SNR)
-noise = np.random.normal(0, variance, size=(n,n))
-Sigma = Sigma_true + (noise + noise.T)/2
-
+variance = norm(Sigma_true, 'fro').value / (np.sqrt(n * n) * SNR)
+noise = np.random.normal(0, variance, size=(n, n))
+Sigma = Sigma_true + (noise + noise.T) / 2
 
 # NC-ADMM heuristic
-Sigma_lr = Rank(n, n, k, M=None, symmetric=True)
-D_vec = Variable(n); D = diag(D_vec)
+Sigma_lr = Rank((n, n), k, M=None, symmetric=True)
+D_vec = Variable(n)
+D = diag(D_vec)
 cost = sum_squares(Sigma - Sigma_lr - D)
 constraints = [D_vec >= 0, Sigma_lr >> 0]
 prob = Problem(Minimize(cost), constraints)
+
 
 def polish_func(sltn):
     matrix = sltn[Sigma_lr.id]
     w, V = np.linalg.eigh(matrix)
     w_sorted_idxs = np.argsort(-w)
     pos_w = w[w_sorted_idxs[:k]]
-    pos_V = V[:,w_sorted_idxs[:k]]
+    pos_V = V[:, w_sorted_idxs[:k]]
     Sigma_tmp = Variable((k, k), symmetric=True)
-    Sigma_small = pos_V*Sigma_tmp*pos_V.T
+    Sigma_small = pos_V * Sigma_tmp * pos_V.T
 
     D_vec2 = Variable(n); D = diag(D_vec2)
     cost = sum_squares(Sigma - Sigma_small - D)
@@ -41,6 +43,7 @@ def polish_func(sltn):
     prob = Problem(Minimize(cost), constraints)
     result = prob.solve(solver=SCS)
     return result, {Sigma_lr.id: Sigma_small.value, D_vec.id: D_vec2.value}
+
 
 prob.solve(method="NC-ADMM", solver=SCS, show_progress=True, parallel=False,
            restarts=1, max_iter=10, polish_func=polish_func, polish_depth=10)
@@ -57,7 +60,7 @@ print(sum_squares(Sigma - Sigma_lr.project(Sigma)).value)
 prob.solve(method="relax-round-polish", solver=SCS)
 print("Relax-round-polish value", cost.value)
 
-# Nuclear norm heurstic
+# Nuclear norm heuristic
 gamma = Parameter(nonneg=True)
 Sigma_lr = Variable(n, PSD=True)
 reg = trace(Sigma_lr)

--- a/examples/factor_model.py
+++ b/examples/factor_model.py
@@ -1,5 +1,4 @@
 import cvxpy as cp
-from cvxpy import norm, Variable, diag, sum_squares, Minimize, trace, Problem, Parameter, pos
 import ncvx as nc
 import numpy as np
 
@@ -15,17 +14,17 @@ SNR = 20
 F = rng.standard_normal(size=(n, k))
 D_true = rng.exponential(1, size=(n, 1))
 Sigma_true = F @ F.T + np.diag(D_true)
-variance = norm(Sigma_true, 'fro').value / (np.sqrt(n * n) * SNR)
+variance = cp.norm(Sigma_true, 'fro').value / (np.sqrt(n * n) * SNR)
 noise = rng.normal(0, variance, size=(n, n))
 Sigma = Sigma_true + (noise + noise.T) / 2
 
 # NC-ADMM heuristic
 Sigma_lr = nc.Rank((n, n), k, M=None, symmetric=True)
-D_vec = Variable(n)
-D = diag(D_vec)
-cost = sum_squares(Sigma - Sigma_lr - D)
+D_vec = cp.Variable(n)
+D = cp.diag(D_vec)
+cost = cp.sum_squares(Sigma - Sigma_lr - D)
 constraints = [D_vec >= 0, Sigma_lr >= 0]
-prob = Problem(Minimize(cost), constraints)
+prob = cp.Problem(cp.Minimize(cost), constraints)
 
 
 def polish_func(sltn):
@@ -34,13 +33,13 @@ def polish_func(sltn):
     w_sorted_idxs = np.argsort(-w)
     pos_w = w[w_sorted_idxs[:k]]
     pos_V = V[:, w_sorted_idxs[:k]]
-    Sigma_tmp = Variable((k, k), symmetric=True)
-    Sigma_small = pos_V * Sigma_tmp * pos_V.T
+    Sigma_tmp = cp.Variable((k, k), symmetric=True)
+    Sigma_small = pos_V @ Sigma_tmp @ pos_V.T
 
-    D_vec2 = Variable(n); D = diag(D_vec2)
-    cost = sum_squares(Sigma - Sigma_small - D)
+    D_vec2 = cp.Variable(n); D = cp.diag(D_vec2)
+    cost = cp.sum_squares(Sigma - Sigma_small - D)
     constraints = [D_vec >= 0, Sigma_lr >> 0]
-    prob = Problem(Minimize(cost), constraints)
+    prob = cp.Problem(cp.Minimize(cost), constraints)
     result = prob.solve(solver=cp.SCS)
     return result, {Sigma_lr.id: Sigma_small.value, D_vec.id: D_vec2.value}
 
@@ -48,27 +47,27 @@ def polish_func(sltn):
 prob.solve(method="NC-ADMM", solver=cp.SCS, show_progress=True, parallel=False,
            restarts=1, max_iter=10, polish_func=polish_func, polish_depth=10)
 Sigma_lr.value = Sigma_lr.project(Sigma_lr.value)
-D_vec.value = pos(D_vec).value
-print("NC-ADMM value", cost.value)
+D_vec.value = cp.pos(D_vec).value
+print(f"NC-ADMM value = {cost.value}")
 
 w, V = np.linalg.eigh(Sigma_lr.value)
-print(w, D_vec.value)
-print(sum_squares(Sigma - Sigma_lr - D).value)
-print(sum_squares(Sigma - Sigma_lr.project(Sigma)).value)
+print(f"w = \n{w}\nD = \n{D_vec.value}")
+print(cp.sum_squares(Sigma - Sigma_lr - D).value)
+print(cp.sum_squares(Sigma - Sigma_lr.project(Sigma)).value)
 
 # Relax-round-polish heuristic
 prob.solve(method="relax-round-polish", solver=cp.SCS)
-print("Relax-round-polish value", cost.value)
+print(f"Relax-round-polish value = {cost.value}")
 
 # Nuclear norm heuristic
-gamma = Parameter(nonneg=True)
-Sigma_lr = Variable((n, n), PSD=True)
-reg = trace(Sigma_lr)
-D_vec = Variable(n)
-D = diag(D_vec)
-cost = sum_squares(Sigma - Sigma_lr - D)
+gamma = cp.Parameter(nonneg=True)
+Sigma_lr = cp.Variable((n, n), PSD=True)
+reg = cp.trace(Sigma_lr)
+D_vec = cp.Variable(n)
+D = cp.diag(D_vec)
+cost = cp.sum_squares(Sigma - Sigma_lr - D)
 constraints = [D_vec >= 0]
-prob = Problem(Minimize(cost + gamma*reg), constraints)
+prob = cp.Problem(cp.Minimize(cost + gamma*reg), constraints)
 found_lr = False
 for gamma_val in np.logspace(-2, 2, num=100):
     gamma.value = gamma_val
@@ -77,9 +76,9 @@ for gamma_val in np.logspace(-2, 2, num=100):
     rank = sum(w > 1e-3)
     if rank <= k:
         # Polish.
-        polish_prob = Problem(Minimize(cost),
-                              constraints + [Sigma_lr == Sigma_lr.value])
+        polish_prob = cp.Problem(cp.Minimize(cost),
+                                 constraints + [Sigma_lr == Sigma_lr.value])
         found_lr = True
         break
 assert found_lr
-print("Nuclear norm value", cost.value)
+print(f"Nuclear norm value = {cost.value}")

--- a/examples/graph_isomorphism.py
+++ b/examples/graph_isomorphism.py
@@ -1,6 +1,8 @@
-from cvxpy import *
-from ncvx import *
+import cvxpy as cp
+import ncvx as nc
 import numpy as np
+
+# This example is described in Section 6.6 of the NCVX paper.
 
 np.random.seed(1)
 
@@ -74,10 +76,10 @@ MAX_ITER = 30
 RESTARTS = 5
 
 # NC-ADMM heuristic
-P = Assign((n, n))
-cost = norm(A @ P - P @ B, "fro")
-prob = Problem(Minimize(cost), [])
-prob.solve(method="NC-ADMM", solver=CVXOPT, parallel=False)
+P = nc.Assign((n, n))
+cost = cp.norm(A @ P - P @ B, "fro")
+prob = cp.Problem(cp.Minimize(cost), [])
+prob.solve(method="NC-ADMM", solver=cp.CVXOPT, parallel=False)
 P = P.value
 print("optimal value = ", cost.value)
 print(np.dot(P, np.arange(n) + 1))

--- a/examples/graph_isomorphism.py
+++ b/examples/graph_isomorphism.py
@@ -74,11 +74,10 @@ MAX_ITER = 30
 RESTARTS = 5
 
 # NC-ADMM heuristic
-P = Assign(n,n)
-cost = norm(A*P-P*B, "fro")
+P = Assign((n, n))
+cost = norm(A @ P - P @ B, "fro")
 prob = Problem(Minimize(cost), [])
-prob.solve(method="NC-ADMM")
+prob.solve(method="NC-ADMM", solver=CVXOPT, parallel=False)
 P = P.value
 print("optimal value = ", cost.value)
-print(np.dot(P,np.arange(n)+1))
-
+print(np.dot(P, np.arange(n) + 1))

--- a/examples/job_selection.py
+++ b/examples/job_selection.py
@@ -27,6 +27,7 @@ cost = c.T*z
 constraints = [z >= 0, A*z <= b]
 prob = Problem(Maximize(cost), constraints)
 
+
 def neighbor_func(z_val, cur_merit):
     # Special function for evaluating neighbors.
     resid = np.dot(A, z_val) - b
@@ -48,6 +49,7 @@ def neighbor_func(z_val, cur_merit):
         z_val[i] += op
     return best_merit, z_val
 
+
 # NC-ADMM heuristic
 start = time.time()
 val, resid = prob.solve(method="NC-ADMM", polish_depth=5, show_progress=True, parallel=False,
@@ -56,15 +58,15 @@ print("NC-ADMM residual =", resid)
 print("NC-ADMM value =", val)
 print(time.time() - start)
 
-# # Relax-round-polish heuristic
+# Relax-round-polish heuristic
 # val, resid = prob.solve(method="relax-round-polish", polish_depth=5)
 # print(("Relax-round-polish residual =", resid))
 # print(("Relax-round-polish value =", val))
 
-## Global solution via Gurobi. (Uncooment the code below.)
+# Global solution via Gurobi. (Uncooment the code below.)
 z = Int(n)
-cost = c.T*z
+cost = c.T * z
 prob = Problem(Maximize(cost),
                [z <= a, z >= 0, A*z <= b])
-prob.solve(solver=GUROBI, TimeLimit = 20, verbose=True)
+prob.solve(solver=GUROBI, TimeLimit=20, verbose=True)
 print("Gurobi value =", cost.value)

--- a/examples/job_selection.py
+++ b/examples/job_selection.py
@@ -1,40 +1,39 @@
-from cvxpy import *
-from ncvx import *
+import cvxpy as cp
+import ncvx as nc
 import numpy as np
 import time
-import numba
 
 np.random.seed(1)
 
-m = 100; n = 10*m; k = 10
-print("m =", m, ", n =", n, ", k =", k)
+m = 100; n = 10 * m; k = 10
+print(f"m = {m}, n = {n}, k = {k}")
 
 c = np.random.uniform(0, 1, size=(n, 1))
-A = np.zeros((m*n,1))
-arr = np.arange(m*n)
+A = np.zeros((m * n, 1))
+arr = np.arange(m * n)
 np.random.shuffle(arr)
-positions = arr[0:m*n//k]
-A[positions] = np.random.uniform(0, 5, size=(m*n//k,1))
-A = reshape(A, (m, n)).value
+positions = arr[0: m * n // k]
+A[positions] = np.random.uniform(0, 5, size=(m * n // k, 1))
+A = cp.reshape(A, (m, n)).value
 a = np.random.randint(1, 6, size=(n, 1))
-z_true = np.zeros((n,1))
+z_true = np.zeros((n, 1))
 for i in range(n):
     z_true[i] = np.random.randint(0, a[i])
 b = A.dot(z_true)
 
-z = Integer(n, M=a)
-cost = c.T*z
-constraints = [z >= 0, A*z <= b]
-prob = Problem(Maximize(cost), constraints)
+z = nc.Integer((n, 1), M=a)
+cost = c.T @ z
+constraints = [z >= 0, A @ z <= b]
+prob = cp.Problem(cp.Maximize(cost), constraints)
 
 
 def neighbor_func(z_val, cur_merit):
     # Special function for evaluating neighbors.
     resid = np.dot(A, z_val) - b
     obj = -np.dot(c.T, z_val)
-    best_merit = obj + 10000*np.maximum(resid, 0).sum()
+    best_merit = obj + 10000 * np.maximum(resid, 0).sum()
     best_sltn = None
-    for i in range(z_val.shape):
+    for i in range(z_val.shape[0]):
         vals = [1, -1] if z_val[i] > 0 else [1]
         for op in vals:
             obj2 = obj - op*c[i]
@@ -51,22 +50,25 @@ def neighbor_func(z_val, cur_merit):
 
 
 # NC-ADMM heuristic
-start = time.time()
-val, resid = prob.solve(method="NC-ADMM", polish_depth=5, show_progress=True, parallel=False,
+tic = time.perf_counter()
+val, resid = prob.solve(method="NC-ADMM", solver=cp.CVXOPT,
+                        polish_depth=5, show_progress=True, parallel=False,
                         neighbor_func=neighbor_func, max_iter=25, restarts=5)
-print("NC-ADMM residual =", resid)
-print("NC-ADMM value =", val)
-print(time.time() - start)
+toc = time.perf_counter()
+print(f"NC-ADMM residual = {resid}")
+print(f"NC-ADMM value    = {val}")
+print(f"Solve time = {toc - tic:.4f} seconds.")
 
 # Relax-round-polish heuristic
 # val, resid = prob.solve(method="relax-round-polish", polish_depth=5)
 # print(("Relax-round-polish residual =", resid))
 # print(("Relax-round-polish value =", val))
 
-# Global solution via Gurobi. (Uncooment the code below.)
-z = Int(n)
-cost = c.T * z
-prob = Problem(Maximize(cost),
-               [z <= a, z >= 0, A*z <= b])
-prob.solve(solver=GUROBI, TimeLimit=20, verbose=True)
-print("Gurobi value =", cost.value)
+# Global solution via Gurobi.
+if cp.GUROBI in cp.installed_solvers():
+    z = cp.Variable((n, 1), integer=True)
+    cost = c.T * z
+    prob = cp.Problem(cp.Maximize(cost),
+                      [z <= a, z >= 0, A @ z <= b])
+    prob.solve(solver=cp.GUROBI, TimeLimit=20, verbose=True)
+    print("Gurobi value =", cost.value)

--- a/examples/max_coverage.py
+++ b/examples/max_coverage.py
@@ -1,36 +1,37 @@
-from cvxpy import *
-from ncvx import *
+import cvxpy as cp
+import ncvx as nc
 import numpy as np
 import time
 
 np.random.seed(1)
 
 # Generating problem data
-p = 1.0 / 10 # each set contains np elements (10% of the elements) in expectation
-m = int(3 / p)  # total number of elements in all sets (with repetition) is mnp ~ 3n
-k = int(1/(3*p))  # if you choose k sets randomly they contain knp ~ n/3 element in expectation
+p = 1.0 / 10          # each set contains np elements (10% of the elements) in expectation
+m = int(3 / p)        # total number of elements in all sets (with repetition) is mnp ~ 3n
+k = int(1 / (3 * p))  # if you choose k sets randomly they contain knp ~ n/3 element in expectation
 n = 100
-A = np.random.binomial(1, p, [n, m]);
-w = np.random.rand(1,n)
+A = np.random.binomial(1, p, [n, m])
+w = np.random.rand(1, n)
 
 # NC-ADMM heuristic
-x = Boolean(n)
-y = Choose(m, 1, k)
+x = nc.Boolean((n, 1))
+y = nc.Choose((m, 1), k)
 weight = w * x
-constraints = [A * y >= x]
-prob = Problem(Maximize(weight), constraints)
+constraints = [A @ y >= x]
+prob = cp.Problem(cp.Maximize(weight), constraints)
 
-start = time.time()
+tic = time.perf_counter()
 prob.solve(method="NC-ADMM", parallel=False, verbose=True, polish_depth=0, restarts=1)
-end = time.time()
-print("NC-ADMM solution = ", weight.value)
-print(end - start)
-# Gurobi (uncomment code below)
-x = Bool(n)
-y = Bool(m)
-weight = w * x
-constraints = [sum(y) <= k, A * y >= x]
-prob = Problem(Maximize(weight), constraints)
+toc = time.perf_counter()
+print(f"NC-ADMM solution = {weight.value}")
+print(f"Solve time = {toc - tic:.4f} seconds.")
 
-prob.solve(solver = GUROBI, verbose=True)
-print("GUROBI solution = ", weight.value)
+# Gurobi.
+if cp.GUROBI in cp.installed_solvers():
+    x = cp.Variable(n, boolean=True)
+    y = cp.Variablel(m, boolean=True)
+    weight = w * x
+    constraints = [sum(y) <= k, A @ y >= x]
+    prob = cp.Problem(cp.Maximize(weight), constraints)
+    prob.solve(solver=cp.GUROBI, verbose=True)
+    print(f"GUROBI solution = {weight.value}")

--- a/examples/max_coverage.py
+++ b/examples/max_coverage.py
@@ -1,6 +1,7 @@
 from cvxpy import *
 from ncvx import *
 import numpy as np
+import time
 
 np.random.seed(1)
 
@@ -19,7 +20,6 @@ weight = w * x
 constraints = [A * y >= x]
 prob = Problem(Maximize(weight), constraints)
 
-import time
 start = time.time()
 prob.solve(method="NC-ADMM", parallel=False, verbose=True, polish_depth=0, restarts=1)
 end = time.time()

--- a/examples/regressor_selection.py
+++ b/examples/regressor_selection.py
@@ -1,70 +1,83 @@
-from cvxpy import *
-from ncvx import *
+import cvxpy as cp
+import ncvx as nc
 import numpy as np
 import random
+from multiprocessing import freeze_support
 
-np.random.seed(1)
-random.seed(1)
-
-# Generating problem data
-m = 65; n = 2*m; k = n//10
-print("m =", m, ", n =", n, ", k =", k)
-SNR = 20; M = 1
-A = np.random.randn(m, n)
-x_true = np.random.uniform(-1, 1, size=(n,1))
-zeros = random.sample(list(range(n)), n-k)
-x_true[zeros] = 0
-sigma = norm(A.dot(x_true), 2).value/(np.sqrt(n)*SNR)
-noise = np.random.normal(0, sigma, size=(m,1))
-b = A.dot(x_true) + noise
+# This example is described in Section 6.1 of the NCVX paper.
 
 
-# Best solution using Gurobi after 1 minute. (Uncomment the code below.)
-#x = Variable(n)
-#bound = Bool(n)
-#constr = [abs(x) <= M*bound, sum_entries(bound) <= k]
-#cost = sum_squares(A*x - b)
-#prob = Problem(Minimize(cost), constr)
-#prob.solve(solver=GUROBI, TimeLimit = 60)
-#print("Gurobi value =", cost.value)
-#print("Gurobi solution =\n", np.around(x.value.T, decimals=3))
-#print("--------------------------------------------------------------------")
+def run():
+    np.random.seed(1)
+    random.seed(1)
 
-# NC-ADMM heuristic.
-x = Card(n, k, M)
-cost = sum_squares(A*x - b)
-prob = Problem(Minimize(cost))
-RESTARTS = 5; ITERS = 50
-prob.solve(method="NC-ADMM", restarts=RESTARTS, num_procs = 5, max_iter=ITERS)
-print("NC-ADMM value =", cost.value)
-print("NC-ADMM solution =\n", np.around(x.value.T, decimals=3))
-print("--------------------------------------------------------------------")
+    # Generating problem data
+    m = 65
+    n = 2 * m
+    k = n // 10
+    print(f"m = {m}, n = {n}, k = {k}")
+    SNR = 20
+    M = 1
+    A = np.random.randn(m, n)
+    x_true = np.random.uniform(-1, 1, size=(n, 1))
+    zeros = random.sample(list(range(n)), n - k)
+    x_true[zeros] = 0
+    sigma = cp.norm(A.dot(x_true), 2).value / (np.sqrt(n) * SNR)
+    noise = np.random.normal(0, sigma, size=(m, 1))
+    b = A.dot(x_true) + noise
 
-# Relax-round-polish heurisitc
-prob.solve(method="relax-round-polish")
-print("Relax-round-polish value =", cost.value)
-print("Relax-round-polish solution =\n", np.around(x.value.T, decimals=3))
-print("--------------------------------------------------------------------")
+    # Best solution using Gurobi after 1 minute.
+    if cp.GUROBI in cp.installed_solvers():
+        x = cp.Variable(n)
+        bound = cp.Variable(n, boolean=True)
+        constr = [cp.abs(x) <= M * bound, cp.sum(bound) <= k]
+        cost = cp.sum_squares(A @ x - b)
+        prob = cp.Problem(cp.Minimize(cost), constr)
+        prob.solve(solver=cp.GUROBI, TimeLimit=60)
+        print("Gurobi value =", cost.value)
+        print("Gurobi solution =\n", np.around(x.value.T, decimals=3))
+        print("--------------------------------------------------------------------")
 
-# Lasso heuristic
-gamma = Parameter(nonneg=True)
-reg = norm(x,1)
-cost = sum_squares(A*x - b)
-prob = Problem(Minimize(cost + gamma*reg), [abs(x) <= M])
-found_card = False
-for gamma_val in np.logspace(-2,4,num=100):
-    gamma.value = gamma_val
-    prob.solve()
-    card = sum(abs(x).value > 1e-3)
-    if card <= k:
-        # Polish.
-        polish_prob = Problem(Minimize(cost),
-                              [abs(x) <= (abs(x).value > 1e-3)*M])
-        polish_prob.solve()
-        found_card = True
-        break
-assert found_card
-print("Lasso value =", cost.value)
-print("Lasso solution =\n", np.around(x.value.T, decimals=3))
+    # NC-ADMM heuristic.
+    x = nc.Card(n, k, M)
+    cost = cp.sum_squares(A @ x - b)
+    prob = cp.Problem(cp.Minimize(cost))
+    RESTARTS = 5;
+    ITERS = 50
+    prob.solve(method="NC-ADMM", restarts=RESTARTS,
+               num_procs=5, max_iter=ITERS)
+    print("NC-ADMM value =", cost.value)
+    print("NC-ADMM solution =\n", np.around(x.value.T, decimals=3))
+    print("--------------------------------------------------------------------")
+
+    # Relax-round-polish heuristic
+    prob.solve(method="relax-round-polish")
+    print("Relax-round-polish value =", cost.value)
+    print("Relax-round-polish solution =\n", np.around(x.value.T, decimals=3))
+    print("--------------------------------------------------------------------")
+
+    # Lasso heuristic
+    gamma = cp.Parameter(nonneg=True)
+    reg = cp.norm(x, 1)
+    cost = cp.sum_squares(A * x - b)
+    prob = cp.Problem(cp.Minimize(cost + gamma * reg), [cp.abs(x) <= M])
+    found_card = False
+    for gamma_val in np.logspace(-2, 4, num=100):
+        gamma.value = gamma_val
+        prob.solve()
+        card = sum(cp.abs(x).value > 1e-3)
+        if card <= k:
+            # Polish.
+            polish_prob = cp.Problem(cp.Minimize(cost),
+                                     [cp.abs(x) <= (cp.abs(x).value > 1e-3) * M])
+            polish_prob.solve()
+            found_card = True
+            break
+    assert found_card
+    print("Lasso value =", cost.value)
+    print("Lasso solution =\n", np.around(x.value.T, decimals=3))
 
 
+if __name__ == '__main__':
+    freeze_support()
+    run()

--- a/examples/three_sat.py
+++ b/examples/three_sat.py
@@ -1,49 +1,62 @@
-from cvxpy import *
-from ncvx import *
+import cvxpy as cp
+import ncvx as nc
 import random
 import numpy as np
+from multiprocessing import freeze_support
 
-random.seed(1)
-np.random.seed(1)
-# 3-SAT problem solved with non-convex ADMM
+# This example is described in Section 6.2 of the NCVX paper.
 
-# num_vars_list = np.arange(10,110,10)
-# num_clauses_list = np.arange(10,430,10)
-#num_vars_list = np.arange(10,110,10) #10,110,10
-#num_clauses_list = np.arange(10,440,10) #10,440,10
 
-#data = np.zeros((len(num_clauses_list), len(num_vars_list)))
-#TRIALS = 10
+def run():
+    random.seed(1)
+    np.random.seed(1)
 
-# Generating problem data
-num_clauses = 150
-num_vars = 60;
+    # 3-SAT problem solved with non-convex ADMM
 
-while True:
-    # The 3-SAT clauses.
-    A = np.zeros((num_clauses,num_vars))
-    b = np.zeros((num_clauses, 1))
-    for i in range(num_clauses):
-        clause_vars = random.sample(range(num_vars), 3)
-        # Which variables are negated in the clause?
-        negated = np.array([random.random() < 0.5 for j in range(3)])
-        A[i, clause_vars] = 2*negated - 1
-        b[i] = sum(negated) - 1
-    ## Verifying the problem is feasible. (Uncomment to use Gurobi.)
-    x = Bool(num_vars)
-    prob = Problem(Minimize(0), [A*x <= b])
-    # prob.solve(solver=GUROBI)
-    if prob.status != INFEASIBLE:
-        break
-    else:
-        print("INFEASIBLE")
+    # num_vars_list = np.arange(10,110,10)
+    # num_clauses_list = np.arange(10,430,10)
+    # num_vars_list = np.arange(10,110,10) #10,110,10
+    # num_clauses_list = np.arange(10,440,10) #10,440,10
 
-# NC-ADMM Heuristic
-x = Boolean(num_vars)
-prob = Problem(Minimize(0), [A*x <= b])
-RESTARTS = 10
-result = prob.solve(method="NC-ADMM")
+    # data = np.zeros((len(num_clauses_list), len(num_vars_list)))
+    # TRIALS = 10
 
-satisfied = (A*x.value <= b).sum()
-percent_satisfied = 100*satisfied/num_clauses
-print("%s%% of the clauses were satisfied." % percent_satisfied)
+    # Generating problem data
+    num_clauses = 150
+    num_vars = 60
+
+    while True:
+        # The 3-SAT clauses.
+        A = np.zeros((num_clauses, num_vars))
+        b = np.zeros((num_clauses, 1))
+        for i in range(num_clauses):
+            clause_vars = random.sample(range(num_vars), 3)
+            # Which variables are negated in the clause?
+            negated = np.array([random.random() < 0.5 for j in range(3)])
+            A[i, clause_vars] = 2 * negated - 1
+            b[i] = sum(negated) - 1
+
+        # Verifying the problem is feasible.
+        x = cp.Variable((num_vars, 1), boolean=True)
+        prob = cp.Problem(cp.Minimize(0), [A @ x <= b])
+        if cp.GUROBI in cp.installed_solvers():
+            prob.solve(solver=cp.GUROBI)
+        if prob.status != cp.INFEASIBLE:
+            break
+        else:
+            print("INFEASIBLE")
+
+    # NC-ADMM Heuristic
+    x = nc.Boolean((num_vars, 1))
+    prob = cp.Problem(cp.Minimize(0), [A @ x <= b])
+    RESTARTS = 10
+    result = prob.solve(method="NC-ADMM")
+
+    satisfied = (A @ x.value <= b).sum()
+    percent_satisfied = 100 * satisfied / num_clauses
+    print("%s%% of the clauses were satisfied." % percent_satisfied)
+
+
+if __name__ == '__main__':
+    freeze_support()
+    run()

--- a/examples/tsp.py
+++ b/examples/tsp.py
@@ -1,29 +1,26 @@
-from cvxpy import *
-from ncvx import *
+import cvxpy as cp
+import ncvx as nc
 import numpy as np
 import matplotlib.pyplot as plt
+import time
+from multiprocessing import freeze_support
+
+# This example is described in Section 6.4 of the NCVX paper.
 
 # Traveling salesman problem.
 np.random.seed(1)
 n = 60
 
 # Get locations.
-x = np.random.uniform(-1, 1, size=(n,1))
-y = np.random.uniform(-1, 1, size=(n,1))
-X = np.vstack([x.T,y.T])
+x = np.random.uniform(-1, 1, size=(n, 1))
+y = np.random.uniform(-1, 1, size=(n, 1))
+X = np.vstack([x.T, y.T])
 
 # Make distance matrix.
-D = np.zeros((n,n))
+D = np.zeros((n, n))
 for i in range(n):
     for j in range(n):
-        D[i,j] = norm(X[:,i] - X[:,j]).value
-
-
-# Approximate solution with NC-ADMM
-P = Tour(n)
-cost = vec(D).T*vec(P)
-prob = Problem(Minimize(cost), [])
-
+        D[i, j] = cp.norm(X[:, i] - X[:, j]).value
 
 
 def neighbor_func(Z, cur_merit):
@@ -37,14 +34,14 @@ def neighbor_func(Z, cur_merit):
         c = idxs[b]
         d = idxs[c]
         diff = D[a, c] + D[b, d] - D[a, b] - D[c, d]
-        if (diff < best_diff):
+        if diff < best_diff:
             best_diff = diff
             a_candid = a
             b_candid = b
             c_candid = c
             d_candid = d
 
-    if (best_diff < 0):
+    if best_diff < 0:
         best_merit += diff
         Z[a_candid, c_candid] = 1
         Z[a_candid, b_candid] = 0
@@ -59,25 +56,30 @@ def neighbor_func(Z, cur_merit):
     return best_merit, Z
 
 
+def run():
+    # Approximate solution with NC-ADMM
+    P = nc.Tour(n)
+    cost = cp.vec(D).T @ cp.vec(P)
+    prob = cp.Problem(cp.Minimize(cost), [])
+
+    tic = time.perf_counter()
+    val, result = prob.solve(method="NC-ADMM", polish_depth=5, solver=cp.SCS,
+                             show_progress=True, neighbor_func=neighbor_func,
+                             parallel=True, restarts=1,
+                             max_iter=50)
+    toc = time.perf_counter()
+    print(f"Solve time = {toc - tic:.4f} seconds.")
+    print("final value", cost.value)
+
+    # Plotting
+    ordered = (X @ P.T).value
+    for i in range(n):
+        plt.plot([X[0, i], ordered[0, i]],
+                 [X[1, i], ordered[1, i]],
+                 color='brown', marker='o')
+    plt.show()
 
 
-
-
-
-import time
-start = time.time()
-val, result = prob.solve(method="NC-ADMM", polish_depth=5, solver = SCS,
-                         show_progress=True, neighbor_func=neighbor_func, parallel=True, restarts=1,
-                         max_iter=50)
-end = time.time()
-print(end - start)
-print("final value", cost.value)
-
-# Plotting
-ordered = (X*P.T).value
-for i in range(n):
-    plt.plot([X[0,i], ordered[0,i]],
-             [X[1,i], ordered[1,i]],
-             color = 'brown', marker = 'o')
-
-plt.show()
+if __name__ == '__main__':
+    freeze_support()
+    run()

--- a/ncvx/admm_problem.py
+++ b/ncvx/admm_problem.py
@@ -50,7 +50,7 @@ def admm_inner_iter(data):
     # gamma = cvx.Parameter(nonneg=True)
     merit_func = orig_prob.objective.args[0]
     for constr in orig_prob.constraints:
-        merit_func += gamma_merit*get_constr_error(constr)
+        merit_func += gamma_merit * get_constr_error(constr)
 
     # Form ADMM problem.
     # obj = orig_prob.objective.args[0]
@@ -110,7 +110,7 @@ def admm_inner_iter(data):
                     cur_merit, sltn = neighbor_search(merit_func, old_vars, best_so_far,
                                                       idx, polish_depth)
                 else:
-                    sltn = noncvx_vars[0].z.value.A.copy()
+                    sltn = noncvx_vars[0].z.value.copy()
                     noncvx_vars[0].value = sltn
                     cur_merit = orig_prob.objective.value
 
@@ -411,7 +411,7 @@ def relax_round_polish(self, gamma=1e4, samples=10, sigma=1, polish_depth=5,
             best_so_far[1] = sltn
     # Unpack result.
     for var in rel_prob.variables():
-        var.value = best_so_far[1][var.id]
+        var._value = best_so_far[1][var.id]
 
     return self.objective.value, residual.value
 

--- a/ncvx/annulus.py
+++ b/ncvx/annulus.py
@@ -28,6 +28,7 @@ class Annulus(NonCvxVariable):
         self.r = r
         self.R = R
         assert 0 < r <= R
+        kwargs.pop('shape', None)
         super().__init__((rows, 1), *args, **kwargs)
 
     def _project(self, matrix):

--- a/ncvx/annulus.py
+++ b/ncvx/annulus.py
@@ -18,7 +18,7 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .noncvx_variable import NonCvxVariable
-import cvxpy as cvx
+import cvxpy as cp
 import numpy as np
 
 
@@ -28,26 +28,26 @@ class Annulus(NonCvxVariable):
         self.r = r
         self.R = R
         assert 0 < r <= R
-        super(Annulus, self).__init__(rows, 1, *args, **kwargs)
+        super().__init__((rows, 1), *args, **kwargs)
 
     def _project(self, matrix):
-        if self.R >= cvx.norm(matrix, 2).value >= self.r:
+        if self.R >= cp.norm(matrix, 2).value >= self.r:
             return matrix
-        elif cvx.norm(matrix, 2).value == 0:
+        elif cp.norm(matrix, 2).value == 0:
             result = np.ones(self.shape)
-            return self.r*result/cvx.norm(result, 2).value
-        elif cvx.norm(matrix, 2).value < self.r:
-            return self.r*matrix/cvx.norm(matrix, 2).value
+            return self.r * result / cp.norm(result, 2).value
+        elif cp.norm(matrix, 2).value < self.r:
+            return self.r * matrix / cp.norm(matrix, 2).value
         else:
-            return self.R*matrix/cvx.norm(matrix, 2).value
+            return self.R * matrix / cp.norm(matrix, 2).value
 
     def _restrict(self, matrix):
         # Add restriction that beyond hyperplane at projection onto
         # n-sphere of radius r.
-        return [matrix.T*self >= self.r*cvx.norm(matrix, 2).value]
+        return [matrix.T * self >= self.r * cp.norm(matrix, 2).value]
 
     def relax(self):
         """The convex relaxation.
         """
         constr = super(Annulus, self).relax()
-        return constr + [cvx.norm(self, 2) <= self.R]
+        return constr + [cp.norm(self, 2) <= self.R]

--- a/ncvx/annulus.py
+++ b/ncvx/annulus.py
@@ -21,6 +21,7 @@ from .noncvx_variable import NonCvxVariable
 import cvxpy as cvx
 import numpy as np
 
+
 class Annulus(NonCvxVariable):
     """ A variable satisfying r <= ||x||_2 <= R. """
     def __init__(self, rows, r, R, *args, **kwargs):

--- a/ncvx/assign.py
+++ b/ncvx/assign.py
@@ -61,20 +61,10 @@ class Assign(Boolean):
                 result[row, column] = 1
             return result
 
-    def matrix_to_lists(self, matrix):
-        """Convert a matrix to a list of lists.
-        """
-        rows, cols = matrix.shape
-        lists = []
-        for i in range(rows):
-            lists.append(matrix[i,:].tolist()[0])
-        return lists
-
     # Constrain all entries to be zero that correspond to
     # zeros in the matrix.
     def _restrict(self, matrix):
         return [self == matrix]
-
 
     def _neighbors(self, matrix):
         """Neighbors swap adjacent rows.
@@ -100,4 +90,4 @@ class Assign(Boolean):
         # Col sum == 1.
         col_sum = lu.mul_expr(one_col_vec, obj, (1, self.shape[1]))
         constraints += [lu.create_eq(col_sum, lu.transpose(one_row_vec))]
-        return (obj, constraints)
+        return obj, constraints

--- a/ncvx/assign.py
+++ b/ncvx/assign.py
@@ -28,9 +28,9 @@ class Assign(Boolean):
 
         Assign jobs x workers. Assign one worker to each job.
     """
-    def __init__(self, rows, cols, *args, **kwargs):
-        assert rows >= cols
-        super(Assign, self).__init__(rows=rows, cols=cols, *args, **kwargs)
+    def __init__(self, shape=(), *args, **kwargs):
+        assert shape[0] >= shape[1]
+        super().__init__(shape=shape, *args, **kwargs)
 
     def init_z(self, random):
         if random:
@@ -48,7 +48,7 @@ class Assign(Boolean):
                     result[assignment[j], j] += weights[k]
             self.z.value = result
         else:
-            self.z.value = np.ones(self.shape)/self.shape[1]
+            self.z.value = np.ones(self.shape) / self.shape[1]
 
     # Compute projection with maximal weighted matching.
     def _project(self, matrix):

--- a/ncvx/boolean.py
+++ b/ncvx/boolean.py
@@ -22,8 +22,10 @@ import cvxpy.lin_ops.lin_utils as lu
 from cvxpy import norm
 import numpy as np
 
+
 class Boolean(NonCvxVariable):
     """ A boolean variable. """
+
     # Sets the initial z value to a matrix of 0.5's.
     def init_z(self, random):
         if random:
@@ -33,7 +35,7 @@ class Boolean(NonCvxVariable):
 
     # All values set rounded to zero or 1.
     def _project(self, matrix):
-        return np.around(matrix) #> 0
+        return np.around(matrix)  # > 0
 
     # Constrain all entries to be the value in the matrix.
     def _restrict(self, matrix):
@@ -44,7 +46,7 @@ class Boolean(NonCvxVariable):
         for i in range(self.shape[0]):
             for j in range(self.shape[1]):
                 new_mat = matrix.copy()
-                new_mat[i,j] = 1 - new_mat[i,j]
+                new_mat[i,j] = 1 - new_mat[i, j]
                 neighbors_list += [new_mat]
         return neighbors_list
 

--- a/ncvx/boolean.py
+++ b/ncvx/boolean.py
@@ -18,8 +18,6 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .noncvx_variable import NonCvxVariable
-import cvxpy.lin_ops.lin_utils as lu
-from cvxpy import norm
 import numpy as np
 
 
@@ -46,7 +44,7 @@ class Boolean(NonCvxVariable):
         for i in range(self.shape[0]):
             for j in range(self.shape[1]):
                 new_mat = matrix.copy()
-                new_mat[i,j] = 1 - new_mat[i, j]
+                new_mat[i, j] = 1 - new_mat[i, j]
                 neighbors_list += [new_mat]
         return neighbors_list
 

--- a/ncvx/card.py
+++ b/ncvx/card.py
@@ -23,6 +23,7 @@ from itertools import product
 import numpy as np
 import cvxpy as cp
 
+
 class Card(NonCvxVariable):
     """ A variable with constrained cardinality. """
     # k - the maximum cardinality of the variable.
@@ -30,7 +31,7 @@ class Card(NonCvxVariable):
     def __init__(self, rows, k, M, *args, **kwargs):
         self.k = k
         self.M = M
-        super(Card, self).__init__(rows, 1, *args, **kwargs)
+        super().__init__((rows, 1), *args, **kwargs)
 
     def init_z(self, random):
         """Initializes the value of the replicant variable.

--- a/ncvx/card.py
+++ b/ncvx/card.py
@@ -21,7 +21,7 @@ from .noncvx_variable import NonCvxVariable
 import cvxpy.interface.matrix_utilities as intf
 from itertools import product
 import numpy as np
-import cvxpy as cvx
+import cvxpy as cp
 
 class Card(NonCvxVariable):
     """ A variable with constrained cardinality. """
@@ -66,5 +66,5 @@ class Card(NonCvxVariable):
         """The convex relaxation.
         """
         constr = super(Card, self).relax()
-        return constr + [cvx.norm(self, 1) <= self.k*self.M,
-                         cvx.norm(self, 'inf') <= self.M]
+        return constr + [cp.norm(self, 1) <= self.k * self.M,
+                         cp.norm(self, 'inf') <= self.M]

--- a/ncvx/choose.py
+++ b/ncvx/choose.py
@@ -24,11 +24,11 @@ import cvxpy as cp
 
 class Choose(Boolean):
     """ A variable with k 1's and all other entries 0. """
-    def __init__(self, rows=1, cols=1, k=None, *args, **kwargs):
+    def __init__(self, shape=(1, 1), k=None, *args, **kwargs):
         if k is None:
             raise Exception("Choose requires a value for k.")
         self.k = k
-        super(Choose, self).__init__(rows, cols, *args, **kwargs)
+        super().__init__(shape, *args, **kwargs)
 
     def init_z(self, random):
         """Initialize cloned variable.

--- a/ncvx/choose.py
+++ b/ncvx/choose.py
@@ -19,7 +19,8 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 
 from .boolean import Boolean
 import numpy as np
-import cvxpy as cvx
+import cvxpy as cp
+
 
 class Choose(Boolean):
     """ A variable with k 1's and all other entries 0. """
@@ -33,7 +34,7 @@ class Choose(Boolean):
         """Initialize cloned variable.
         """
         super(Choose, self).init_z(random)
-        self.z.value = self.k*self.z.value/self.z.value.sum()
+        self.z.value = self.k * self.z.value / self.z.value.sum()
 
     # The k-largest values are set to 1. The remainder are set to 0.
     def _project(self, matrix):
@@ -46,7 +47,7 @@ class Choose(Boolean):
     # In the relaxation, we have 0 <= var <= 1.
     def relax(self):
         constr = super(Choose, self).relax()
-        constr += [cvx.sum(self) == self.k]
+        constr += [cp.sum(self) == self.k]
         return constr
 
     def _neighbors(self, matrix):
@@ -60,10 +61,10 @@ class Choose(Boolean):
                             if k != i and l != j and \
                                0 <= k < self.shape[0] and \
                                0 <= l < self.shape[1] and \
-                               matrix[k,l] == 0:
+                               matrix[k, l] == 0:
                                new_mat = matrix.copy()
-                               new_mat[i,j] = 0
-                               new_mat[k,l] = 1
+                               new_mat[i, j] = 0
+                               new_mat[k, l] = 1
                                neighbors_list += [new_mat]
 
         return neighbors_list

--- a/ncvx/group_assign.py
+++ b/ncvx/group_assign.py
@@ -18,7 +18,7 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .boolean import Boolean
-import cvxpy as cvx
+import cvxpy as cp
 import lap
 import numpy as np
 
@@ -39,10 +39,10 @@ class GroupAssign(Boolean):
         sum_i X_ij = s_j
         X_ij \in {0, 1}
     """
-    def __init__(self, rows, cols, col_sum, *args, **kwargs):
-        assert rows >= cols
-        assert rows == sum(col_sum)
-        super(GroupAssign, self).__init__(rows=rows, cols=cols, *args, **kwargs)
+    def __init__(self, shape, col_sum, *args, **kwargs):
+        assert shape[0] >= shape[1]
+        assert shape[0] == sum(col_sum)
+        super().__init__(shape, *args, **kwargs)
         self.col_sum = col_sum
 
     def init_z(self, random):
@@ -88,12 +88,12 @@ class GroupAssign(Boolean):
         for i in range(self.shape[0]-1):
             # Add to neighbor only when the candidate person (row) is in a different group.
             new_mat = matrix.copy()
-            for j in range(i+1, self.shape[0]-1):
+            for j in range(i + 1, self.shape[0] - 1):
                 if np.all(matrix[i, :] == matrix[j, :]):
                     continue
                 else:
-                    new_mat[j,:] = matrix[i,:]
-                    new_mat[i,:] = matrix[j,:]
+                    new_mat[j, :] = matrix[i, :]
+                    new_mat[i, :] = matrix[j, :]
                     neighbors_list += [new_mat]
                     break
         return neighbors_list
@@ -101,8 +101,8 @@ class GroupAssign(Boolean):
     def relax(self):
         """Convex relaxation.
         """
-        constr = super(GroupAssign, self).relax()
+        constr = super().relax()
         return constr + [
-            cvx.sum(self, axis=1) == 1,
-            cvx.sum(self, axis=0) == self.col_sum[np.newaxis, :]
+            cp.sum(self, axis=1) == 1,
+            cp.sum(self, axis=0) == self.col_sum[np.newaxis, :]
         ]

--- a/ncvx/integer.py
+++ b/ncvx/integer.py
@@ -18,19 +18,19 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .noncvx_variable import NonCvxVariable
-import cvxpy as cvx
+import cvxpy as cp
 import numpy as np
 
 class Integer(NonCvxVariable):
     """ An integer variable. """
     # M - upper bound on |x|
-    def __init__(self, rows=1, cols=1, M=None, *args, **kwargs):
+    def __init__(self, shape, M=None, *args, **kwargs):
         if M is None or np.any(M <= 0):
             raise Exception("Integer requires positive values for M.")
         self.M = np.floor(M)
-        if np.isscalar(self.M) and (rows, cols) != (1,1):
-            self.M = self.M*np.ones((rows,cols))
-        super(Integer, self).__init__(rows, cols, *args, **kwargs)
+        if np.isscalar(self.M) and shape != (1, 1):
+            self.M = self.M * np.ones(shape)
+        super().__init__(shape, *args, **kwargs)
 
     def init_z(self, random):
         """Initializes the value of the replicant variable.
@@ -56,4 +56,4 @@ class Integer(NonCvxVariable):
         return neighbors_list
 
     def relax(self):
-        return [cvx.abs(self) <= self.M]
+        return [cp.abs(self) <= self.M]

--- a/ncvx/integer.py
+++ b/ncvx/integer.py
@@ -21,6 +21,7 @@ from .noncvx_variable import NonCvxVariable
 import cvxpy as cp
 import numpy as np
 
+
 class Integer(NonCvxVariable):
     """ An integer variable. """
     # M - upper bound on |x|

--- a/ncvx/noncvx_variable.py
+++ b/ncvx/noncvx_variable.py
@@ -18,18 +18,18 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import abc
-import cvxpy
+import cvxpy as cp
 import cvxpy.interface as intf
 import numpy as np
 from six import with_metaclass
 
 
-class NonCvxVariable(with_metaclass(abc.ABCMeta, cvxpy.Variable)):
+class NonCvxVariable(with_metaclass(abc.ABCMeta, cp.Variable)):
     def __init__(self, rows, cols, *args, **kwargs):
         super(NonCvxVariable, self).__init__((rows, cols,), *args, **kwargs)
         self.noncvx = True
-        self.z = cvxpy.Parameter(self.shape)
-        self.u = cvxpy.Parameter(self.shape)
+        self.z = cp.Parameter(self.shape)
+        self.u = cp.Parameter(self.shape)
         self.u.value = np.zeros(self.shape)
 
     def init_u(self, random=False):
@@ -52,7 +52,7 @@ class NonCvxVariable(with_metaclass(abc.ABCMeta, cvxpy.Variable)):
         """Distance from matrix to projection.
         """
         proj_mat = self.project(matrix)
-        return cvxpy.norm(cvxpy.vec(matrix - proj_mat), 2).value
+        return cp.norm(cp.vec(matrix - proj_mat), 2).value
 
     # Project the matrix into the space defined by the non-convex constraint.
     # Returns the updated matrix.

--- a/ncvx/noncvx_variable.py
+++ b/ncvx/noncvx_variable.py
@@ -17,16 +17,15 @@ You should have received a copy of the GNU General Public License
 along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import abc
+from abc import abstractmethod
 import cvxpy as cp
 import cvxpy.interface as intf
 import numpy as np
-from six import with_metaclass
 
 
-class NonCvxVariable(with_metaclass(abc.ABCMeta, cp.Variable)):
-    def __init__(self, rows, cols, *args, **kwargs):
-        super(NonCvxVariable, self).__init__((rows, cols,), *args, **kwargs)
+class NonCvxVariable(cp.Variable):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.noncvx = True
         self.z = cp.Parameter(self.shape)
         self.u = cp.Parameter(self.shape)
@@ -56,8 +55,8 @@ class NonCvxVariable(with_metaclass(abc.ABCMeta, cp.Variable)):
 
     # Project the matrix into the space defined by the non-convex constraint.
     # Returns the updated matrix.
-    @abc.abstractmethod
-    def _project(matrix):
+    @abstractmethod
+    def _project(self, matrix):
         return NotImplemented
 
     # Wrapper to validate matrix and update curvature.
@@ -76,6 +75,6 @@ class NonCvxVariable(with_metaclass(abc.ABCMeta, cp.Variable)):
         return []
 
     # Fix the variable so it obeys the non-convex constraint.
-    @abc.abstractmethod
+    @abstractmethod
     def _restrict(self, matrix):
         return NotImplemented

--- a/ncvx/orthog.py
+++ b/ncvx/orthog.py
@@ -18,14 +18,14 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .noncvx_variable import NonCvxVariable
-import cvxpy as cvx
+import cvxpy as cp
 import numpy as np
-import scipy.sparse as sp
+
 
 class Orthog(NonCvxVariable):
     """ A variable satisfying X^TX = I. """
     def __init__(self, size, *args, **kwargs):
-        super(Orthog, self).__init__(size, size, *args, **kwargs)
+        super().__init__(shape=(size, size), *args, **kwargs)
 
     def init_z(self, random):
         """Initializes the value of the replicant variable.
@@ -48,6 +48,6 @@ class Orthog(NonCvxVariable):
         """
         rows, cols = self.shape
         constr = super(Orthog, self).relax()
-        mat  = cvx.bmat([[np.eye(rows), self],
-                         [X.T, np.eye(cols)]])
+        mat = cp.bmat([[np.eye(rows), self],
+                       [X.T, np.eye(cols)]])
         return constr + [mat >> 0]

--- a/ncvx/partition.py
+++ b/ncvx/partition.py
@@ -18,16 +18,15 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .boolean import Boolean
-import cvxopt
 import numpy as np
-from itertools import product
-import cvxpy as cvx
+import cvxpy as cp
+
 
 class Partition(Boolean):
     """ A boolean matrix with exactly one 1 in each row.
     """
-    def __init__(self, rows, cols, *args, **kwargs):
-        super(Partition, self).__init__(rows, cols, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def _project(self, matrix):
         """The largest value in each row is set to 1.
@@ -81,5 +80,5 @@ class Partition(Boolean):
     def relax(self):
         """Convex relaxation.
         """
-        constr = super(Partition, self).relax()
-        return constr + [cvx.sum(self, axis=1) == 1]
+        constr = super().relax()
+        return constr + [cp.sum(self, axis=1) == 1]

--- a/ncvx/rank.py
+++ b/ncvx/rank.py
@@ -80,8 +80,8 @@ class SymmRank(AsymmRank):
         w_sorted_idxs = np.argsort(-w)
         pos_w = w[w_sorted_idxs[:self.k]]
         pos_V = V[:, w_sorted_idxs[:self.k]]
-        Sigma = cp.Symmetric(self.k, self.k)
-        return [self == pos_V*Sigma*pos_V.T]
+        Sigma = cp.Variable(shape=(self.k, self.k), symmetric=True)
+        return [self == pos_V @ Sigma @ pos_V.T]
 
     def relax(self):
         return super().relax() + [self == self.T]

--- a/ncvx/sphere.py
+++ b/ncvx/sphere.py
@@ -18,13 +18,14 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from .noncvx_variable import NonCvxVariable
-import cvxpy as cvx
+import cvxpy as cp
 import numpy as np
+
 
 class Sphere(NonCvxVariable):
     """ A variable satisfying ||x||_2 = 1. """
     def __init__(self, rows=1, *args, **kwargs):
-        super(Sphere, self).__init__(rows, 1, *args, **kwargs)
+        super().__init__(shape=(rows, 1), *args, **kwargs)
 
     def init_z(self, random):
         """Initializes the value of the replicant variable.
@@ -39,14 +40,14 @@ class Sphere(NonCvxVariable):
     def _project(self, matrix):
         if np.all(matrix == 0):
             result = np.ones(self.shape)
-            return result/cvx.norm(result, 2).value
+            return result / cp.norm(result, 2).value
         else:
-            return matrix/cvx.norm(matrix, 2).value
+            return matrix / cp.norm(matrix, 2).value
 
     # Constrain all entries to be the value in the matrix.
     def _restrict(self, matrix):
         return [self == matrix]
 
     def relax(self):
-        constr = super(Sphere, self).relax()
-        return constr + [cvx.norm(self, 2) <= 1]
+        constr = super().relax()
+        return constr + [cp.norm(self, 2) <= 1]

--- a/ncvx/tests/test_vars.py
+++ b/ncvx/tests/test_vars.py
@@ -29,8 +29,10 @@ class TestVars(unittest.TestCase):
     """ Unit tests for the variable types. """
     def setUp(self):
         self._places = 5      # tune the tolerance down a bit as part of CVDOPT -> SCS switch
-        self._solve = {'method': 'NC-ADMM', 'solver': cp.SCS, 'parallel': False}
-        pass
+        # Parallel running during unit testing seems to cause some snags. So set
+        # to false here.
+        self._solve = {'method': 'NC-ADMM', 'solver': cp.SCS, 'parallel': False,
+                       'verbose': False}
 
     def test_boolean(self):
         """Test boolean variable."""

--- a/ncvx/tests/test_vars.py
+++ b/ncvx/tests/test_vars.py
@@ -35,7 +35,7 @@ class TestVars(unittest.TestCase):
     def test_boolean(self):
         """Test boolean variable."""
         x = Variable((5, 4))
-        y = Boolean(5, 4)
+        y = Boolean((5, 4))
         p = Problem(Minimize(sum(1 - x) + sum(x)), [x == y])
         result = p.solve(**self._solve)
         self.assertAlmostEqual(result[0], 20, places=self._places)
@@ -45,7 +45,7 @@ class TestVars(unittest.TestCase):
         # This time test a scalar variable, while restricting to a single entry
         # of a Boolean matrix.
         x = Variable()
-        p = Problem(Minimize(sum(1 - x) + sum(x)), [x == Boolean(5, 4)[0, 0]])
+        p = Problem(Minimize(sum(1 - x) + sum(x)), [x == Boolean((5, 4))[0, 0]])
         result = p.solve(**self._solve)
         self.assertAlmostEqual(result[0], 1, places=self._places)
         self.assertAlmostEqual(x.value * (1 - x.value), 0, places=self._places)
@@ -53,7 +53,7 @@ class TestVars(unittest.TestCase):
     def test_choose(self):
         """Test choose variable."""
         x = Variable((5, 4))
-        y = Choose(5, 4, k=4)
+        y = Choose((5, 4), k=4)
         p = Problem(Minimize(sum(1 - x) + sum(x)), [x == y])
         result = p.solve(**self._solve)
         self.assertAlmostEqual(result[0], 20, places=self._places)
@@ -64,11 +64,9 @@ class TestVars(unittest.TestCase):
     # Test card variable.
     def test_card(self):
         x = Card(5, k=3, M=1)
-        p = Problem(Maximize(sum(x)),
-                    [x <= 1, x >= 0])
+        p = Problem(Maximize(sum(x)), [x <= 1, x >= 0])
         result = p.solve(**self._solve)
 
-        places = 5
         self.assertAlmostEqual(result[0], 3, places=self._places)
         for v in np.nditer(x.value):
             self.assertAlmostEqual(v * (1 - v), 0, places=self._places)
@@ -76,8 +74,8 @@ class TestVars(unittest.TestCase):
 
         # Should be equivalent to x == choose.
         x = Variable((5, 4))
-        c = Choose(5, 4, k=4)
-        b = Boolean(5, 4)
+        c = Choose((5, 4), k=4)
+        b = Boolean((5, 4))
         p = cp.Problem(Minimize(sum(1 - x) + sum(x)),
                        [x == c, x == b])
         result = p.solve(**self._solve)
@@ -89,7 +87,7 @@ class TestVars(unittest.TestCase):
     def test_permutation(self):
         x = Variable((1, 5))
         c = np.array([[1, 2, 3, 4, 5]])
-        perm = Assign(5, 5)
+        perm = Assign((5, 5))
         p = Problem(Minimize(sum(x)), [x == c*perm])
         result = p.solve(**self._solve)
         self.assertAlmostEqual(result[0], 15, places=self._places)

--- a/ncvx/tests/test_vars.py
+++ b/ncvx/tests/test_vars.py
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License
 along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from cvxpy import *
 import cvxpy as cp
 from ncvx import *
 import numpy as np
@@ -33,29 +32,29 @@ class TestVars(unittest.TestCase):
 
     # Test boolean variable.
     def test_boolean(self):
-        x = Variable((5, 4))
+        x = cp.Variable((5, 4))
         y = Boolean(5, 4)
-        p = Problem(Minimize(sum(1-x) + sum(x)), [x == y])
-        result = p.solve(method="NC-ADMM", solver=CVXOPT)
+        p = cp.Problem(cp.Minimize(cp.sum(1 - x) + cp.sum(x)), [x == y])
+        result = p.solve(method="NC-ADMM", solver=cp.CVXOPT)
         self.assertAlmostEqual(result[0], 20)
         for i in range(x.shape[0]):
             for j in range(x.shape[1]):
                 v = x.value[i, j]
-                self.assertAlmostEqual(v*(1-v), 0)
+                self.assertAlmostEqual(v * (1 - v), 0)
 
-        x = Variable()
-        p = Problem(Minimize(sum(1-x) + sum(x)), [x == Boolean(5,4)[0,0]])
-        result = p.solve(method="NC-ADMM", solver=CVXOPT)
+        x = cp.Variable()
+        p = cp.Problem(cp.Minimize(sum(1 - x) + sum(x)), [x == Boolean(5, 4)[0, 0]])
+        result = p.solve(method="NC-ADMM", solver=cp.CVXOPT)
         self.assertAlmostEqual(result[0], 1)
-        self.assertAlmostEqual(x.value*(1-x.value), 0)
+        self.assertAlmostEqual(x.value*(1 - x.value), 0)
 
     # Test choose variable.
     def test_choose(self):
-        x = Variable((5, 4))
+        x = cp.Variable((5, 4))
         y = Choose(5, 4, k=4)
-        p = Problem(Minimize(sum(1-x) + sum(x)),
+        p = cp.Problem(cp.Minimize(sum(1 - x) + sum(x)),
                     [x == y])
-        result = p.solve(method="NC-ADMM", solver=CVXOPT)
+        result = p.solve(method="NC-ADMM", solver=cp.CVXOPT)
         self.assertAlmostEqual(result[0], 20)
         for i in range(x.shape[0]):
             for j in range(x.shape[1]):
@@ -66,7 +65,7 @@ class TestVars(unittest.TestCase):
     # Test card variable.
     def test_card(self):
         x = Card(5, k=3, M=1)
-        p = Problem(Maximize(cp.sum(x)),
+        p = cp.Problem(cp.Maximize(cp.sum(x)),
             [x <= 1, x >= 0])
         result = p.solve(method="NC-ADMM")
         self.assertAlmostEqual(result[0], 3)
@@ -74,13 +73,13 @@ class TestVars(unittest.TestCase):
             self.assertAlmostEqual(v*(1-v), 0)
         self.assertAlmostEqual(x.value.sum(), 3)
 
-        #should be equivalent to x == choose
-        x = Variable((5, 4))
+        # Should be equivalent to x == choose.
+        x = cp.Variable((5, 4))
         c = Choose(5, 4, k=4)
         b = Boolean(5, 4)
-        p = Problem(Minimize(sum(1-x) + sum(x)),
+        p = cp.Problem(cp.Minimize(sum(1 - x) + sum(x)),
                     [x == c, x == b])
-        result = p.solve(method="NC-ADMM", solver=CVXOPT)
+        result = p.solve(method="NC-ADMM", solver=cp.CVXOPT)
         self.assertAlmostEqual(result[0], 20)
         for i in range(x.shape[0]):
             for j in range(x.shape[1]):
@@ -89,10 +88,10 @@ class TestVars(unittest.TestCase):
 
     # Test permutation variable.
     def test_permutation(self):
-        x = Variable((1, 5))
-        c = np.array([[1,2,3,4,5]])
+        x = cp.Variable((1, 5))
+        c = np.array([[1, 2, 3, 4, 5]])
         perm = Assign(5, 5)
-        p = Problem(Minimize(cp.sum(x)), [x == c*perm])
+        p = cp.Problem(cp.Minimize(cp.sum(x)), [x == c*perm])
         result = p.solve(method="NC-ADMM")
         self.assertAlmostEqual(result[0], 15)
         assert_array_almost_equal(sorted(np.nditer(x.value)), c.ravel())

--- a/ncvx/tests/test_vars.py
+++ b/ncvx/tests/test_vars.py
@@ -18,79 +18,80 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import cvxpy as cp
+import pytest
 from cvxpy import sum, Minimize, Maximize, Problem, Variable
 from ncvx import *
 import numpy as np
-import unittest
 from numpy.testing import assert_array_almost_equal
 
+solve_args = {'method': 'NC-ADMM', 'solver': cp.SCS, 'parallel': True,
+              'verbose': False}
 
-class TestVars(unittest.TestCase):
-    """ Unit tests for the variable types. """
-    def setUp(self):
-        self._places = 5      # tune the tolerance down a bit as part of CVDOPT -> SCS switch
-        # Parallel running during unit testing seems to cause some snags. So set
-        # to false here.
-        self._solve = {'method': 'NC-ADMM', 'solver': cp.SCS, 'parallel': False,
-                       'verbose': False}
 
-    def test_boolean(self):
-        """Test boolean variable."""
-        x = Variable((5, 4))
-        y = Boolean((5, 4))
-        p = Problem(Minimize(sum(1 - x) + sum(x)), [x == y])
-        result = p.solve(**self._solve)
-        self.assertAlmostEqual(result[0], 20, places=self._places)
-        for v in np.nditer(x.value):
-            self.assertAlmostEqual(v * (1 - v), 0, places=self._places)
+def approx(x, abs=1e-5, *args, **kwargs):
+    return pytest.approx(x, abs=abs, *args, **kwargs)
 
-        # This time test a scalar variable, while restricting to a single entry
-        # of a Boolean matrix.
-        x = Variable()
-        p = Problem(Minimize(sum(1 - x) + sum(x)), [x == Boolean((5, 4))[0, 0]])
-        result = p.solve(**self._solve)
-        self.assertAlmostEqual(result[0], 1, places=self._places)
-        self.assertAlmostEqual(x.value * (1 - x.value), 0, places=self._places)
 
-    def test_choose(self):
-        """Test choose variable."""
-        x = Variable((5, 4))
-        y = Choose((5, 4), k=4)
-        p = Problem(Minimize(sum(1 - x) + sum(x)), [x == y])
-        result = p.solve(**self._solve)
-        self.assertAlmostEqual(result[0], 20, places=self._places)
-        for v in np.nditer(x.value):
-            self.assertAlmostEqual(v * (1 - v), 0, places=self._places)
-        self.assertAlmostEqual(x.value.sum(), 4, places=self._places)
+def test_boolean():
+    """Test boolean variable."""
+    x = Variable((5, 4))
+    y = Boolean((5, 4))
+    p = Problem(Minimize(sum(1 - x) + sum(x)), [x == y])
+    result = p.solve(**solve_args)
+    assert result[0] == approx(20)
+    for v in np.nditer(x.value):
+        assert v * (1 - v) == approx(0)
 
-    # Test card variable.
-    def test_card(self):
-        x = Card(5, k=3, M=1)
-        p = Problem(Maximize(sum(x)), [x <= 1, x >= 0])
-        result = p.solve(**self._solve)
+    # This time test a scalar variable, while restricting to a single entry
+    # of a Boolean matrix.
+    x = Variable()
+    p = Problem(Minimize(sum(1 - x) + sum(x)), [x == Boolean((5, 4))[0, 0]])
+    result = p.solve(**solve_args)
+    assert result[0] == approx(1)
+    assert x.value * (1 - x.value) == approx(0)
 
-        self.assertAlmostEqual(result[0], 3, places=self._places)
-        for v in np.nditer(x.value):
-            self.assertAlmostEqual(v * (1 - v), 0, places=self._places)
-        self.assertAlmostEqual(x.value.sum(), 3, places=self._places)
 
-        # Should be equivalent to x == choose.
-        x = Variable((5, 4))
-        c = Choose((5, 4), k=4)
-        b = Boolean((5, 4))
-        p = cp.Problem(Minimize(sum(1 - x) + sum(x)),
-                       [x == c, x == b])
-        result = p.solve(**self._solve)
-        self.assertAlmostEqual(result[0], 20, places=self._places)
-        for v in np.nditer(x.value):
-            self.assertAlmostEqual(v * (1 - v), 0, places=self._places)
+def test_choose():
+    """Test choose variable."""
+    x = Variable((5, 4))
+    y = Choose((5, 4), k=4)
+    p = Problem(Minimize(sum(1 - x) + sum(x)), [x == y])
+    result = p.solve(**solve_args)
+    assert result[0] == approx(20)
+    for v in np.nditer(x.value):
+        assert v * (1 - v) == approx(0)
+    assert x.value.sum() == approx(4)
 
-    # Test permutation variable.
-    def test_permutation(self):
-        x = Variable((1, 5))
-        c = np.array([[1, 2, 3, 4, 5]])
-        perm = Assign((5, 5))
-        p = Problem(Minimize(sum(x)), [x == c*perm])
-        result = p.solve(**self._solve)
-        self.assertAlmostEqual(result[0], 15, places=self._places)
-        assert_array_almost_equal(sorted(np.nditer(x.value)), c.ravel())
+
+def test_card():
+    """Test card variable."""
+    x = Card(5, k=3, M=1)
+    p = Problem(Maximize(sum(x)), [x <= 1, x >= 0])
+    result = p.solve(**solve_args)
+
+    assert result[0] == approx(3)
+    for v in np.nditer(x.value):
+        assert v * (1 - v) == approx(0)
+    assert x.value.sum() == approx(3)
+
+    # Should be equivalent to x == choose.
+    x = Variable((5, 4))
+    c = Choose((5, 4), k=4)
+    b = Boolean((5, 4))
+    p = cp.Problem(Minimize(sum(1 - x) + sum(x)),
+                   [x == c, x == b])
+    result = p.solve(**solve_args)
+    assert result[0] == approx(20)
+    for v in np.nditer(x.value):
+        assert v * (1 - v) == approx(0)
+
+
+def test_permutation():
+    """Test permutation variable."""
+    x = Variable((1, 5))
+    c = np.array([[1, 2, 3, 4, 5]])
+    perm = Assign((5, 5))
+    p = Problem(Minimize(sum(x)), [x == c * perm])
+    result = p.solve(**solve_args)
+    assert result[0] == approx(15)
+    assert_array_almost_equal(sorted(np.nditer(x.value)), c.ravel())

--- a/ncvx/tour.py
+++ b/ncvx/tour.py
@@ -85,14 +85,14 @@ class Tour(Assign):
             c = idxs[b]
             d = idxs[c]
 
-            new_mat[a,c] = 1
-            new_mat[a,b] = 0
+            new_mat[a, c] = 1
+            new_mat[a, b] = 0
 
-            new_mat[b,d] = 1
-            new_mat[b,c] = 0
+            new_mat[b, d] = 1
+            new_mat[b, c] = 0
 
-            new_mat[c,b] = 1
-            new_mat[c,d] = 0
+            new_mat[c, b] = 1
+            new_mat[c, d] = 0
 
             neighbors_list += [new_mat]
         return neighbors_list
@@ -100,11 +100,11 @@ class Tour(Assign):
     def relax(self):
         """Convex relaxation.
         """
-        constr = super(Tour, self).relax()
+        constr = super().relax()
         # Ensure it's a tour.
         n = self.shape[0]
         # Diagonal == 0 constraint.
         constr += [cp.diag(self) == 0]
         # Spectral constraint.
         mat_val = np.cos(2 * np.pi / n) * np.eye(n) + 4 * np.ones((n, n)) / n
-        return constr + [mat_val >> (self + self.T) / 2]
+        return constr + [mat_val >= (self + self.T) / 2]

--- a/ncvx/tour.py
+++ b/ncvx/tour.py
@@ -19,16 +19,17 @@ along with CVXPY.  If not, see <http://www.gnu.org/licenses/>.
 
 from .assign import Assign
 import numpy as np
-import cvxpy as cvx
+import cvxpy as cp
 
 # TODO change to cycle.
+
 
 class Tour(Assign):
     """ A permutation matrix that describes a single cycle.
         e.g. 1->3->5->2->4->1
     """
     def __init__(self, n, *args, **kwargs):
-        super(Tour, self).__init__(rows=n, cols=n, *args, **kwargs)
+        super().__init__(shape=(n, n), *args, **kwargs)
 
     # Compute projection with maximal weighted matching.
     def _project(self, matrix):
@@ -103,7 +104,7 @@ class Tour(Assign):
         # Ensure it's a tour.
         n = self.shape[0]
         # Diagonal == 0 constraint.
-        constr += [cvx.diag(self) == 0]
+        constr += [cp.diag(self) == 0]
         # Spectral constraint.
-        mat_val = np.cos(2*np.pi/n)*np.eye(n) + 4*np.ones((n,n))/n
-        return constr + [mat_val >> (self + self.T)/2]
+        mat_val = np.cos(2 * np.pi / n) * np.eye(n) + 4 * np.ones((n, n)) / n
+        return constr + [mat_val >> (self + self.T) / 2]

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup
 
 setup(
     name='ncvx',
-    version='0.1.9',
+    version='0.2.0',
     author='Steven Diamond, Reza Takapoui, Stephen Boyd',
-     author_email='diamond@cs.stanford.edu, takapoui@stanford.edu, boyd@stanford.edu',
+    author_email='diamond@cs.stanford.edu, takapoui@stanford.edu, boyd@stanford.edu',
     packages=['ncvx'],
     license='GPLv3',
     zip_safe=False,
-    install_requires=["cvxpy >= 1.0.0", "lap", "scsprox"],
+    install_requires=["cvxpy >= 1.1", "lap", "scsprox >= 0.2"],
     use_2to3=True,
     url='http://github.com/cvxgrp/ncvx/',
     description='A CVXPY extension for problems with convex objective and decision variables from a nonconvex set.',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     packages=['ncvx'],
     license='GPLv3',
     zip_safe=False,
-    install_requires=["cvxpy >= 1.1", "lap", "scsprox >= 0.2"],
+    install_requires=["cvxpy >= 1.1", "lap", "scsprox >= 0.2", "numpy"],
     use_2to3=True,
     url='http://github.com/cvxgrp/ncvx/',
     description='A CVXPY extension for problems with convex objective and decision variables from a nonconvex set.',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     packages=['ncvx'],
     license='GPLv3',
     zip_safe=False,
+    python_requires='>=3.6',
     install_requires=["cvxpy >= 1.1", "lap", "scsprox >= 0.2", "numpy"],
     use_2to3=True,
     url='http://github.com/cvxgrp/ncvx/',


### PR DESCRIPTION
A collection of mods while upgrading to CVXPY >= 1.1.13:
- Require python >= 3.6 (no harm since CVXPY 1.1 has that same requirement).
- Modify the nonconvex variables to take shape tuples, instead of the previous row, col ints. The new behavior is more consistent with CVXPY 1.
- Some minor PEP 8 formatting mods.
- Ensure all the tests and examples are working.
- Point to a new [scsprox fork.](https://github.com/bettbra/scsprox)

There's more to do to be sure, including sprucing up various docstrings. But that can wait for a separate pull request; seems more useful right now to restore the base to operation.